### PR TITLE
v25 Hit Sound FX Parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,10 @@ fn read_item<R: Read + Seek>(
         // fix (5.39)
         reader.seek(SeekFrom::Current(1))?;
     }
+    if version >= 25 {
+        item.hit_sound_fx = read_str(reader); // e.g. "BandageCannonPlayerHitFx"
+        item.hit_sound_fx_hash = reader.read_u32::<LittleEndian>()?;
+    }
 
     Ok(item)
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -98,6 +98,8 @@ pub struct Item {
     pub extra_option2: String,
     pub punch_option: String,
     pub description: String,
+    pub hit_sound_fx: String,
+    pub hit_sound_fx_hash: u32,
 }
 
 impl ItemDatabase {
@@ -186,6 +188,8 @@ impl Item {
             extra_option2: String::new(),
             punch_option: String::new(),
             description: String::new(),
+            hit_sound_fx: String::new(),
+            hit_sound_fx_hash: 0,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and storing item hit sound effect properties (including sound file reference and hash value) for version 25+ item data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->